### PR TITLE
Allow custom user model

### DIFF
--- a/longerusername/admin.py
+++ b/longerusername/admin.py
@@ -5,10 +5,14 @@ from django.contrib.auth.models import User
 
 from longerusername.forms import UserCreationForm, UserChangeForm
 
-class LongerUserNameUserAdmin(UserAdmin):
+class LongerUserNameUserAdminMixin(object):
     add_form = UserCreationForm
     form = UserChangeForm
+    
 
 if get_user_model() == User:
+    class LongerUserNameUserAdmin(LongerUserNameUserAdminMixin, UserAdmin):
+        pass
+
     admin.site.unregister(User)
     admin.site.register(User, LongerUserNameUserAdmin)

--- a/longerusername/admin.py
+++ b/longerusername/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
 
@@ -8,5 +9,6 @@ class LongerUserNameUserAdmin(UserAdmin):
     add_form = UserCreationForm
     form = UserChangeForm
 
-admin.site.unregister(User)
-admin.site.register(User, LongerUserNameUserAdmin)
+if get_user_model() == User:
+    admin.site.unregister(User)
+    admin.site.register(User, LongerUserNameUserAdmin)


### PR DESCRIPTION
In case of custom user models, it's left up to user to extend or directly use `LongerUserNameUserAdmin` as desired.
